### PR TITLE
Fix delete issue when ssh key contain slash

### DIFF
--- a/lib/TG/SSH.pm
+++ b/lib/TG/SSH.pm
@@ -366,7 +366,7 @@ sub removeKey {
     chomp($key);
 
     # Delete keys from remote host
-    my $sed  = "sed -i '/$key/d' ".$this->{"remote_authorized_keys_path"};
+    my $sed  = "sed -i '#$key#d' ".$this->{"remote_authorized_keys_path"};
     my $host = $this->{'hostname'};
     my $port = $this->{'port'};
     my $user = $this->{'user'};


### PR DESCRIPTION
I issue when drop ssh key in my server.
Infact my key contain slach charecter.
I purpose to use # separator for sed call.