### PR TITLE
Change git clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Clone tg in a folder (ex: ~/bin/tg) :
 
 ```sh
 mkdir ~/bin
-git clone git@github.com:root-gg/tg.git ~/bin/tg
+git clone https://github.com/root-gg/tg.git ~/bin/tg
 ```
 
 Change your PATH to add ~/bin/tg :


### PR DESCRIPTION
Most part of the world does not have any permission on this repository. Might be more logical to use the public https link for clone